### PR TITLE
docs: fixed usage of `write_graphml_file` as per latest update

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ let partitions = community::louvain::louvain_partitions(&graph, false, None, Non
 ```rust,ignore
 use graphrs::{readwrite, GraphSpecs};
 let graph = readwrite::graphml::read_graphml_file("/some/file.graphml", GraphSpecs::directed());
-readwrite::graphml::write_graphml(&graph, "/some/other/file.graphml");
+readwrite::graphml::write_graphml_file(&graph, "/some/other/file.graphml");
 ```
 
 ### Get an adjacency matrix


### PR DESCRIPTION
Reference: https://docs.rs/graphrs/latest/graphrs/readwrite/graphml/fn.write_graphml_file.html