### PR TITLE
Feature-gate lapack.lib

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    #[cfg(feature = "adjacency_matrix")]
     println!("cargo:rustc-link-lib=dylib=lapack");
 }


### PR DESCRIPTION
Prevent linking failures when `lapack` is neither used nor installed:
> LINK : fatal error LNK1181: cannot open input file 'lapack.lib'