### PR TITLE
Fix line break in error message string

### DIFF
--- a/src/graph/creation.rs
+++ b/src/graph/creation.rs
@@ -88,7 +88,7 @@ where
                 kind: ErrorKind::DuplicateEdge,
                 message: format!(
                     "A duplicate edge was found: {}. \
-                    Set the `GraphSpecs.edge_dedupe_strategy` if a different
+                    Set the `GraphSpecs.edge_dedupe_strategy` if a different \
                     behavior is desired.",
                     edge
                 ),


### PR DESCRIPTION
The string was missing a line continuation indicator and contained a literal line beak instead.